### PR TITLE
Add League Endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ migrate:
 	@docker-compose -f docker-compose.yml up -d
 	@docker-compose -f docker-compose.yml exec backend bash -c "cd /app/backend && go run . -migrate" || (echo "Migration failed, halting" && exit 1)
 
+nuke-migrations:
+	@echo "💥 Truncating migrations table"
+	@docker-compose -f docker-compose.yml exec database bash -c "psql -d powerplay -c 'TRUNCATE migrations';"
+	@$(MAKE) migrate
+
 production_image:
 	docker build -f build/Dockerfile.production -t powerplay .
 
@@ -14,8 +19,6 @@ production_debug:
 
 run_local_image:
 	docker run -p 127.0.0.1:9001:9001/tcp powerplay:latest
-
-
 
 test:
 	@echo "🚀 Testing code: Running go test inside the backend container"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,50 @@
 
 ![image](https://github.com/jak103/powerplay/assets/16627408/4ec3df62-d760-40c6-aa57-fa63eaaaf61b)
 
-**Working Logo, Working Title**
 
 [![Go](https://github.com/jak103/powerplay/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/jak103/powerplay/actions/workflows/go.yml)
+
+## Table of Contents
+- [Adding and Updating API Endpoints](#adding-and-updating-api-endpoints)
+
+## Helpful Commands
+### Clear and Re-run Migrations
+Sometimes you need to clear out migrations due to a model change. 
+While we are in early development we've decided to drop and recreate
+migrations vs. source control and continuously run them. You can easily
+drop the migrations table and have go auto migrate any changes.
+
+** Note this will not drop columns / tables  
+** This needs to be ran while docker is running
+
+```shell
+make nuke-migrations
+```
+
+### Run all Go tests 
+Ability to quickly run all go tests to ensure your changes
+pass all tests before committing code.
+
+** This needs to be ran while docker is running
+
+```shell
+make test 
+```
+
+## Adding and Updating API Endpoints
+
+### Ensure Model is Created and Up to Date
+1. Navigate to the models directory: \
+   `backend/internal/models`
+
+### Add API Endpoint
+1. Navigate to the server directory: \
+    `backend/internal/server/apis`
+
+### Add DB methods used in API endpoint
+1. Navigate to the db directory: \
+    `backend/internal/db`
+
+### Update Open API docs**
+1. Navigate to the open api spec directory: \
+   `static/oas/v1`

--- a/backend/internal/db/league.go
+++ b/backend/internal/db/league.go
@@ -1,0 +1,10 @@
+package db
+
+import "github.com/jak103/powerplay/internal/models"
+
+// GetLeagues todo: investigate: Struct session has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation.
+func (s session) GetLeagues() ([]models.League, error) {
+	leagues := make([]models.League, 0)
+	err := s.connection.Find(&leagues)
+	return resultsOrError(leagues, err)
+}

--- a/backend/internal/models/league.go
+++ b/backend/internal/models/league.go
@@ -2,6 +2,6 @@ package models
 
 type League struct {
 	DbModel
-	Name  string //`json:"name"`
-	Teams []Team //`json:"teams"`//
+	Name string `json:"name"`
+	// Teams []*Team `json:"teams" gorm:"many2many:league_teams"`
 }

--- a/backend/internal/server/apis/league/league.go
+++ b/backend/internal/server/apis/league/league.go
@@ -1,0 +1,35 @@
+package league
+
+import (
+	"encoding/json"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jak103/powerplay/internal/db"
+	"github.com/jak103/powerplay/internal/server/apis"
+	"github.com/jak103/powerplay/internal/server/services/auth"
+	"github.com/jak103/powerplay/internal/utils/log"
+)
+
+func init() {
+	apis.RegisterHandler(fiber.MethodGet, "/leagues", auth.Public, getLeaguesHandler)
+}
+
+func getLeaguesHandler(c *fiber.Ctx) error {
+	db := db.GetSession(c)
+	leagues, err := db.GetLeagues()
+	if err != nil {
+		// todo: create ticket to standardize this error message and pass in model name
+		log.WithErr(err).Alert("Failed to get all leagues from the database")
+		return err
+	}
+
+	jsonData, err := json.Marshal(leagues)
+	if err != nil {
+		// todo: create ticket to standardize this error message and pass in model name
+		log.WithErr(err).Alert("Failed to serialize leagues response payload")
+		return err
+	}
+
+	c.Type("json")
+
+	return c.Send(jsonData)
+}

--- a/backend/internal/server/apis/league/league.go
+++ b/backend/internal/server/apis/league/league.go
@@ -1,12 +1,12 @@
 package league
 
 import (
-	"encoding/json"
 	"github.com/gofiber/fiber/v2"
 	"github.com/jak103/powerplay/internal/db"
 	"github.com/jak103/powerplay/internal/server/apis"
 	"github.com/jak103/powerplay/internal/server/services/auth"
-	"github.com/jak103/powerplay/internal/utils/log"
+	"github.com/jak103/powerplay/internal/utils/locals"
+	"github.com/jak103/powerplay/internal/utils/responder"
 )
 
 func init() {
@@ -14,6 +14,7 @@ func init() {
 }
 
 func getLeaguesHandler(c *fiber.Ctx) error {
+	log := locals.Logger(c)
 	db := db.GetSession(c)
 	leagues, err := db.GetLeagues()
 	if err != nil {
@@ -22,14 +23,5 @@ func getLeaguesHandler(c *fiber.Ctx) error {
 		return err
 	}
 
-	jsonData, err := json.Marshal(leagues)
-	if err != nil {
-		// todo: create ticket to standardize this error message and pass in model name
-		log.WithErr(err).Alert("Failed to serialize leagues response payload")
-		return err
-	}
-
-	c.Type("json")
-
-	return c.Send(jsonData)
+	return responder.OkWithData(c, leagues)
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	// Blank imports for apis to cause init functions to run
 	_ "github.com/jak103/powerplay/internal/server/apis/auth"
 	_ "github.com/jak103/powerplay/internal/server/apis/chat"
+	_ "github.com/jak103/powerplay/internal/server/apis/league"
 	_ "github.com/jak103/powerplay/internal/server/apis/notifications"
 	_ "github.com/jak103/powerplay/internal/server/apis/stats"
 	_ "github.com/jak103/powerplay/internal/server/apis/user"

--- a/static/oas/v1/leagues/leagues.yaml
+++ b/static/oas/v1/leagues/leagues.yaml
@@ -1,0 +1,44 @@
+paths:
+  leagues:
+    get:
+      tags:
+        - Leagues
+      summary: Get All Leagues
+      description: |
+        Get all leagues
+      responses:
+        200:
+          description: The response body should contain the list of leagues
+          content:
+            application/json:
+              schema:
+                $ref: '#/schemas/GetLeaguesResponse'
+        400:
+          $ref: "../common/errors.yml#/responses/BadRequest"
+
+components:
+  schemas:
+    GetLeaguesResponse:
+      type: object
+      properties:
+        status_code:
+          $ref: "../common/schemas.yml#/schemas/StatusCode200"
+        status_string:
+          $ref: "../common/schemas.yml#/schemas/StatusString200"
+        request_id:
+          $ref: "../common/schemas.yml#/schemas/RequestId"
+        response_data:
+          type: object
+          properties:
+            leagues:
+              type: array
+              description: All leagues
+              example:
+              - id: 1
+                created_at: "2009-11-10T23:00:00Z"
+                updated_at: "2009-11-10T23:00:00Z"
+                #teams:
+                #  id: 1
+                #  created_at: "2009-11-10T23:00:00Z"
+                #  updated_at: "2009-11-10T23:00:00Z"
+                #  name: Tripping

--- a/static/oas/v1/openapi.yml
+++ b/static/oas/v1/openapi.yml
@@ -13,12 +13,14 @@ paths:
     $ref: "./auth/auth.yml#/paths/auth"
   /shotsongoal:
     $ref: "./stats/shotsongoal.yml#/paths/shotsOnGoal"   
-  /user:
-    $ref: "./users/users.yml#/paths/user"
   /penaltyTypes:
     $ref: "./stats/penalties.yml#/paths/penaltyTypes"
+  /leagues:
+    $ref: "./leagues/leagues.yaml#/paths/leagues"
   /penalties:
     $ref: "./stats/penalties.yml#/paths/penalties"
+  /user:
+    $ref: "./users/users.yml#/paths/user"
 
   # /[URL path]
   #$ref: "./[Relative path starting from v1]#/paths/[yml path]"


### PR DESCRIPTION
Add League Endpoint

**Why**
We want a league endpoint in order to display all leagues that exist.

**How**
Add nuke-migrations to makefile to drop and recreate migrations. Update README.md to have instructions on make commands and how to add an endpoint. Add db methods to fetch leagues. Add handler to return all leagues. Add docs to retrieve leagues.